### PR TITLE
Read SYMTYPE_TEXTURE* large objs and read their names

### DIFF
--- a/mojoshader_effects.c
+++ b/mojoshader_effects.c
@@ -622,11 +622,8 @@ static void readsmallobjects(const uint32 numsmallobjects,
               || object->type == MOJOSHADER_SYMTYPE_TEXTURE1D
               || object->type == MOJOSHADER_SYMTYPE_TEXTURE2D
               || object->type == MOJOSHADER_SYMTYPE_TEXTURE3D
-              || object->type == MOJOSHADER_SYMTYPE_TEXTURECUBE)
-        {
-            // No-op. Why is this even here?
-        } // else if
-        else if (object->type == MOJOSHADER_SYMTYPE_SAMPLER
+              || object->type == MOJOSHADER_SYMTYPE_TEXTURECUBE
+              || object->type == MOJOSHADER_SYMTYPE_SAMPLER
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER1D
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER2D
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER3D
@@ -807,7 +804,12 @@ static void readlargeobjects(const uint32 numlargeobjects,
                 } // if
             }
         } // if
-        else if (object->type == MOJOSHADER_SYMTYPE_SAMPLER
+        else if (object->type == MOJOSHADER_SYMTYPE_TEXTURE
+              || object->type == MOJOSHADER_SYMTYPE_TEXTURE1D
+              || object->type == MOJOSHADER_SYMTYPE_TEXTURE2D
+              || object->type == MOJOSHADER_SYMTYPE_TEXTURE3D
+              || object->type == MOJOSHADER_SYMTYPE_TEXTURECUBE
+              || object->type == MOJOSHADER_SYMTYPE_SAMPLER
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER1D
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER2D
               || object->type == MOJOSHADER_SYMTYPE_SAMPLER3D


### PR DESCRIPTION
Objects (small and large) of type `MOJOSHADER_SYMTYPE_TEXTURE*` contain names, just like objects of type `MOJOSHADER_SYMTYPE_SAMPLER*`.